### PR TITLE
Fix gallery ignoring uppercase image extensions

### DIFF
--- a/src/assets/photography/README.md
+++ b/src/assets/photography/README.md
@@ -13,10 +13,16 @@ files, no code changes.
    ```
 
    - The `YYYY-MM-DD` date prefix controls ordering — photos are shown **newest first**
-     (highest date at the top) on both the homepage and `/photography`.
+     (highest date at the top) on both the homepage and `/photography`. Zero-pad the month
+     and day (`2026-07-05`, not `2026-7-5`) so ordering is always correct.
    - The `short-description` part becomes the image's alt text (hyphens turn into spaces),
-     so keep it readable and lowercase, e.g. `2026-07-05-sunset-over-the-rhine.jpg`.
-   - Supported extensions: `.jpg`, `.jpeg`, `.png`, `.webp`, `.avif`.
+     so keep it readable and lowercase, e.g. `2026-07-05-sunset-over-the-rhine.jpg`. It's
+     optional — a bare date like `2026-07-05.jpg` works too (just no alt text).
+   - Supported extensions: `.jpg`, `.jpeg`, `.png`, `.webp`, `.avif` — **any capitalization**,
+     so the uppercase `.JPG`/`.JPEG` that cameras export work as-is.
+
+   > RAW files (e.g. Minolta `.mrw`) can't go here — browsers can't display them and the
+   > optimizer can't read them. Develop your RAW in an editor and **export to JPEG** first.
 
 3. Commit and push. The build automatically optimizes the image (resized `srcset` +
    AVIF/WebP) and adds it to the gallery.

--- a/src/photos.ts
+++ b/src/photos.ts
@@ -7,26 +7,43 @@ export type Photo = {
 
 // Auto-discover every image dropped into `src/assets/photography/`.
 // Adding a photo is just: drop a file there + commit — no code changes needed.
+// Both lower- and upper-case extensions are matched (globs are case-sensitive on
+// Linux, and cameras typically export uppercase `.JPG`/`.JPEG`).
 const modules = import.meta.glob<{ default: ImageMetadata }>(
-    "./assets/photography/*.{jpeg,jpg,png,webp,avif}",
+    [
+        "./assets/photography/*.{jpeg,jpg,png,webp,avif}",
+        "./assets/photography/*.{JPEG,JPG,PNG,WEBP,AVIF}",
+    ],
     { eager: true },
 );
 
-// Turn a file path like ".../2026-07-05-sunset-over-the-rhine.jpg" into
-// readable alt text: "sunset over the rhine".
+// Pull the filename out of a full module path, without its extension.
+function filenameOf(path: string): string {
+    return (path.split("/").pop() ?? path).replace(/\.[^.]+$/, "");
+}
+
+// Turn a filename like "2026-07-05-sunset-over-the-rhine" into readable alt
+// text: "sunset over the rhine". Tolerates non-zero-padded dates and falls back
+// to empty (decorative) alt when the filename is only a date.
 function altFromPath(path: string): string {
-    const filename = path.split("/").pop() ?? path;
-    return filename
-        .replace(/\.[^.]+$/, "") // strip extension
-        .replace(/^\d{4}-\d{2}-\d{2}-?/, "") // strip YYYY-MM-DD date prefix
+    return filenameOf(path)
+        .replace(/^\d{4}-\d{1,2}-\d{1,2}-?/, "") // strip YYYY-M-D date prefix
         .replace(/-/g, " ") // hyphens -> spaces
         .trim();
 }
 
-// Sort newest first: filenames are date-prefixed, so a descending sort by
-// path puts the most recent photos at the top.
+// Extract a sortable timestamp from a leading YYYY-M-D date prefix (padding
+// tolerant). Files without a date prefix sort last.
+function dateKey(path: string): number {
+    const m = filenameOf(path).match(/^(\d{4})-(\d{1,2})-(\d{1,2})/);
+    if (!m) return -Infinity;
+    return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+}
+
+// Sort newest first by date prefix, falling back to filename for ties or
+// undated files.
 export const photos: Photo[] = Object.entries(modules)
-    .sort(([a], [b]) => b.localeCompare(a))
+    .sort(([a], [b]) => dateKey(b) - dateKey(a) || b.localeCompare(a))
     .map(([path, mod]) => ({
         src: mod.default,
         alt: altFromPath(path),


### PR DESCRIPTION
## Summary

Photos uploaded to `src/assets/photography/` with **uppercase extensions** (e.g. `2026-06-21.JPEG`, `2026-07-2.JPEG` — the default output of most cameras) never appeared on the site. The photo-discovery glob in `src/photos.ts` only matched lowercase extensions, and file globs are case-sensitive on the Linux build, so the build silently skipped them and the gallery rendered its empty state.

## Changes

- **Case-insensitive matching** (`src/photos.ts`): the `import.meta.glob` now matches both lower- and upper-case extensions, so `.JPG`/`.JPEG` (and friends) are picked up. This is what makes the already-uploaded photos appear.
- **Padding-tolerant dates**: the date-prefix strip tolerates non-zero-padded dates (`YYYY-M-D`), and alt text falls back to empty (decorative) when a filename is only a date.
- **Robust ordering**: photos sort newest-first by a parsed date key (padding-independent) instead of a raw string compare.
- **README** (`src/assets/photography/README.md`): documents that uppercase extensions work, recommends zero-padded dates, and clarifies that RAW files (e.g. Minolta `.mrw`) must be exported to JPEG first — browsers can't display RAW and the optimizer can't read it.

## Verification

- `pnpm build` now optimizes **both** previously-ignored photos (2.9 MB and 1 MB sources → small responsive WebP variants); before, zero were generated.
- Both pages render two `<img>` with `srcset`, newest-first; confirmed via a Playwright screenshot of `/photography` in dark mode — the two real photos display in the grid.

## Note

This branch was restarted from `master` because the previous PR (#6) that introduced the photography section was already merged; this is follow-up work, not a continuation of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzZToebinTHGjSeTKnaX4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzZToebinTHGjSeTKnaX4o)_